### PR TITLE
lapis.py center fix and text wrapping

### DIFF
--- a/cogs/lapis.py
+++ b/cogs/lapis.py
@@ -8,22 +8,99 @@ class Lapis:
     @commands.command(pass_context=True, no_pm=True)
     async def lapis(self, ctx, message, *):
         image = Image.open('data/blak_template.jpg')
+		
         draw = ImageDraw.Draw(image)
-        (x, y) = (175, 700)
-        if len(message) > 15:
-            message1 = message[:15]
-            message2 = message[15:]
-            message = message1 + "\r\n" + message2
+        
+		# Dimensions for text box
+		boxWidth = image.size[0]
+		
+		boxHeight = image.size[1] * 1 / 4
+		
+		# arbitrary beginning size; this will change if the message is too big
+		fontSize = 100
+		
+		font = ImageFont.truetype('data/theboldfont.ttf', fontSize)
+		
+		textSize = font.getsize(message)
+		
+		textWidth = textSize[0]
+		
+		textHeight = textSize[1]
+		
+		# our lines 
+		lines = []
+		
+		line = ''
+		
+		if textWidth > boxWidth:
+			words = message.split()
+			
+			isHeightGood = False
+			
+			while not isHeightGood:
+				
+				height = 0
+				
+				for word in words:
+					
+					# For the special kids who make really long nonsense words to try and break the bot
+					# While the size of the word is larger than the image width, shrink the font
+					while font.getsize(word)[0] > boxWidth:
+						fontSize -= 5
+						
+						font = ImageFont.truetype('data/theboldfont.ttf', fontSize)
+						
+					textSize = font.getsize(line + word)
+					
+					if(textSize[0] < boxWidth):
+						line += (word + ' ')
+					
+					# Line is too long; add previous line and starta new one
+					else:
+						height += font.getsize(line)[1]
+						
+						isHeightGood = True
+						
+						lines.append(line)
+						
+						line = word + ' '
+						
+						# check if the new height is too long. If it is, reduce font size
+						if (height + font.getsize(line)[1]) > boxHeight:
+							isHeightGood = false
+							
+							fontSize -= 5
+							
+							font = ImageFont.truetype('data/theboldfont.ttf', fontSize)
+							
+							break
+				
+				# Grab leftover line and add it to the collection
+				lines.append(line)
+		else:
+			lines.append(message)
+		
         color = '#000000'  # black color
         outline = '#FFFFFF'
-        font = ImageFont.truetype('data/theboldfont.ttf', size=100)
-        draw.text((x, y), message, fill=outline, font=font)
-        font = ImageFont.truetype('data/theboldfont.ttf', size=99)
-        draw.text((x + 1, y - 1), message, fill=color, font=font)
+		
+		y = int(image.size[1] * 3 / 4)
+		
+		for line in lines:
+			textWidth = font.getsize(line)[0]
+			
+			center = (int(image.size[0] / 2 - textWidth / 2), y)
+			
+			draw.text(center, line, outline, font)
+			
+			draw.text(center, line, color, font - 1)
+		
         image.save('data/lapis_edit.png')
+		
         area = ctx.message.channel
-        with open('data/lapis_edit.png', 'rb') as file:
-            await self.bot.send_file(area, file)
+        
+		with open('data/lapis_edit.png', 'rb') as file:
+			
+			await self.bot.send_file(area, file)
 
 
 


### PR DESCRIPTION
I did it. 

The text should be centered, and now depending on the length of the message we can resize and wrap the text to ensure it all fits in the image.

Currently, the text is on the bottom 1 / 4 of the image, but we can change that if you'd like.