### PR TITLE
Updated uwu command to work more like the mock command

### DIFF
--- a/cogs/fun.py
+++ b/cogs/fun.py
@@ -122,15 +122,21 @@ class Fun(commands.Cog):
 
     @commands.command()
     async def uwu(self, ctx, *, message):
-        uwus = ['UwU', 'Uwu', 'uwU', 'ÚwÚ', 'uwu', '☆w☆', '✧w✧',
-                '♥w♥', '︠uw ︠u', '(uwu)', 'OwO', 'owo', 'Owo', 'owO']
+        """
+        UwU-ifies any message you give it... no matter the size owo
+        """
+        uwus = ['UwU', 'xwx', 'DwD', 'ÚwÚ', 'uwu', '☆w☆', '✧w✧',
+                '♥w♥', '︠uw ︠u', '(uwu)', 'OwO', 'owo', 'Owo', 'owO', '( ͡° ͜ʖ ͡°)']
         res = message.replace("r", "w").replace(
             "l", "w").replace("L", "W").replace("R", "W")
         res = res.replace("the ", "da ").replace(
             "The ", "Da ").replace("THE ", "DA ")
         res = res.replace("th", "d").replace("TH", "D")
         res = res.replace("\n", " " + random.choice(uwus) + "\n")
-        await ctx.send(res + ' ' + random.choice(uwus))
+        # once da uwu-ified message has been genewated, dewete da owd message Uwu
+        await ctx.message.delete()
+        # and send one "as" da usew who invoked da command ÚwÚ
+        await ctx.send(f"{ctx.user.mention} > {res + ' ' + random.choice(uwus)}")
 
     @commands.command(aliases=['chickenbob', 'cb', 'seachicken', 'mock'])
     async def chicken(self, ctx, *, message):


### PR DESCRIPTION
UwU now formats the output like the mock command does (`@caller > some cursed bs`) and deletes the invoking message. I also updated some of the uwu faces that I didn't much care for, and added some comments and a docstring.